### PR TITLE
Use MD5 checksums when downloading serpent decay, nfy data

### DIFF
--- a/serpent/generate_dec_fpy.py
+++ b/serpent/generate_dec_fpy.py
@@ -10,10 +10,17 @@ filename = {
     'nfy': 'sss_endfb71.nfy'
 }
 
+md5s = {
+    'decay': 'ad346888d55427c3f25d39f7fed3e659',
+    'nfy': '0420894a296871cd08f68def84526d0e',
+}
+
 with TemporaryDirectory() as tmpdir:
     for sublib in ('decay', 'nfy'):
         # download and extract from zip file
-        download(f'https://www.nndc.bnl.gov/endf/b7.1/zips/ENDF-B-VII.1-{sublib}.zip')
+        download(
+            f'https://www.nndc.bnl.gov/endf/b7.1/zips/ENDF-B-VII.1-{sublib}.zip',
+            checksum=md5s[sublib])
         with zipfile.ZipFile(f'ENDF-B-VII.1-{sublib}.zip') as z:
             z.extractall(path=tmpdir)
 


### PR DESCRIPTION
Checksums are taken from the [NNDC download page](https://www.nndc.bnl.gov/endf/b7.1/download.html) and passed to ``download`` to help ensure the correct zipfiles are downloaded.

Really great to see the agreement between the two codes!